### PR TITLE
スパース行列用のソルバを実装

### DIFF
--- a/Face2Face.xcodeproj/project.pbxproj
+++ b/Face2Face.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		14418B911CF4415300E5E266 /* KSConjugateGradient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSConjugateGradient.h; sourceTree = "<group>"; };
 		14A109E61CBF335A008591D2 /* KSNormalEquationSolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSNormalEquationSolver.h; sourceTree = "<group>"; };
 		14A109E71CBF3508008591D2 /* KSCholeskyDecomposition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSCholeskyDecomposition.h; sourceTree = "<group>"; };
 		14A109E81CBF3BB0008591D2 /* KSNESolverFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSNESolverFactory.h; sourceTree = "<group>"; };
@@ -105,6 +106,7 @@
 				F803D4741CF351DC003579DA /* KSSparseOptimizer.h */,
 				14A109E61CBF335A008591D2 /* KSNormalEquationSolver.h */,
 				14A109E71CBF3508008591D2 /* KSCholeskyDecomposition.h */,
+				14418B911CF4415300E5E266 /* KSConjugateGradient.h */,
 				14A109E81CBF3BB0008591D2 /* KSNESolverFactory.h */,
 			);
 			path = Math;

--- a/Face2Face.xcodeproj/project.pbxproj
+++ b/Face2Face.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		14E2ED591CB3AAED008D7B8A /* KSOptimizerForNLLS.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14E2ED571CB3AAED008D7B8A /* KSOptimizerForNLLS.cpp */; };
+		14E2ED591CB3AAED008D7B8A /* KSDenseOptimizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14E2ED571CB3AAED008D7B8A /* KSDenseOptimizer.cpp */; };
 		14E2ED6B1CB3D473008D7B8A /* ofTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14E2ED691CB3D472008D7B8A /* ofTest.cpp */; };
 		E4328149138ABC9F0047C5CB /* openFrameworksDebug.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E4328148138ABC890047C5CB /* openFrameworksDebug.a */; };
 		E4B69E200A3A1BDC003C02F2 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4B69E1D0A3A1BDC003C02F2 /* main.cpp */; };
@@ -49,8 +49,8 @@
 		14A109E71CBF3508008591D2 /* KSCholeskyDecomposition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSCholeskyDecomposition.h; sourceTree = "<group>"; };
 		14A109E81CBF3BB0008591D2 /* KSNESolverFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSNESolverFactory.h; sourceTree = "<group>"; };
 		14E2ED561CB3A98B008D7B8A /* KSMath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSMath.h; sourceTree = "<group>"; };
-		14E2ED571CB3AAED008D7B8A /* KSOptimizerForNLLS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KSOptimizerForNLLS.cpp; sourceTree = "<group>"; };
-		14E2ED5A1CB3AB92008D7B8A /* KSOptimizerForNLLS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSOptimizerForNLLS.h; sourceTree = "<group>"; };
+		14E2ED571CB3AAED008D7B8A /* KSDenseOptimizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KSDenseOptimizer.cpp; sourceTree = "<group>"; };
+		14E2ED5A1CB3AB92008D7B8A /* KSDenseOptimizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSDenseOptimizer.h; sourceTree = "<group>"; };
 		14E2ED671CB3B549008D7B8A /* KSTypeDef.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSTypeDef.h; sourceTree = "<group>"; };
 		14E2ED691CB3D472008D7B8A /* ofTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTest.cpp; sourceTree = "<group>"; };
 		14E2ED6A1CB3D472008D7B8A /* ofTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTest.h; sourceTree = "<group>"; };
@@ -96,8 +96,8 @@
 			children = (
 				14E2ED561CB3A98B008D7B8A /* KSMath.h */,
 				14E2ED671CB3B549008D7B8A /* KSTypeDef.h */,
-				14E2ED571CB3AAED008D7B8A /* KSOptimizerForNLLS.cpp */,
-				14E2ED5A1CB3AB92008D7B8A /* KSOptimizerForNLLS.h */,
+				14E2ED571CB3AAED008D7B8A /* KSDenseOptimizer.cpp */,
+				14E2ED5A1CB3AB92008D7B8A /* KSDenseOptimizer.h */,
 				14A109E61CBF335A008591D2 /* KSNormalEquationSolver.h */,
 				14A109E71CBF3508008591D2 /* KSCholeskyDecomposition.h */,
 				14A109E81CBF3BB0008591D2 /* KSNESolverFactory.h */,
@@ -291,7 +291,7 @@
 				F8496C631CB1147A00F301C3 /* ofxTimeMeasurements.cpp in Sources */,
 				E4B69E210A3A1BDC003C02F2 /* ofApp.cpp in Sources */,
 				14E2ED6B1CB3D473008D7B8A /* ofTest.cpp in Sources */,
-				14E2ED591CB3AAED008D7B8A /* KSOptimizerForNLLS.cpp in Sources */,
+				14E2ED591CB3AAED008D7B8A /* KSDenseOptimizer.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Face2Face.xcodeproj/project.pbxproj
+++ b/Face2Face.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		E4328149138ABC9F0047C5CB /* openFrameworksDebug.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E4328148138ABC890047C5CB /* openFrameworksDebug.a */; };
 		E4B69E200A3A1BDC003C02F2 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4B69E1D0A3A1BDC003C02F2 /* main.cpp */; };
 		E4B69E210A3A1BDC003C02F2 /* ofApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4B69E1E0A3A1BDC003C02F2 /* ofApp.cpp */; };
+		F803D4751CF351DC003579DA /* KSSparseOptimizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F803D4731CF351DC003579DA /* KSSparseOptimizer.cpp */; };
 		F8496C631CB1147A00F301C3 /* ofxTimeMeasurements.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8496C5C1CB1147A00F301C3 /* ofxTimeMeasurements.cpp */; };
 /* End PBXBuildFile section */
 
@@ -63,6 +64,8 @@
 		E4B6FCAD0C3E899E008CF71C /* openFrameworks-Info.plist */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text.plist.xml; path = "openFrameworks-Info.plist"; sourceTree = "<group>"; };
 		E4EB691F138AFCF100A09F29 /* CoreOF.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = CoreOF.xcconfig; path = ../../../libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig; sourceTree = SOURCE_ROOT; };
 		E4EB6923138AFD0F00A09F29 /* Project.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Project.xcconfig; sourceTree = "<group>"; };
+		F803D4731CF351DC003579DA /* KSSparseOptimizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KSSparseOptimizer.cpp; sourceTree = "<group>"; };
+		F803D4741CF351DC003579DA /* KSSparseOptimizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSSparseOptimizer.h; sourceTree = "<group>"; };
 		F8496C581CB1147A00F301C3 /* tree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tree.h; sourceTree = "<group>"; };
 		F8496C5C1CB1147A00F301C3 /* ofxTimeMeasurements.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofxTimeMeasurements.cpp; sourceTree = "<group>"; };
 		F8496C5D1CB1147A00F301C3 /* ofxTimeMeasurements.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxTimeMeasurements.h; sourceTree = "<group>"; };
@@ -98,6 +101,8 @@
 				14E2ED671CB3B549008D7B8A /* KSTypeDef.h */,
 				14E2ED571CB3AAED008D7B8A /* KSDenseOptimizer.cpp */,
 				14E2ED5A1CB3AB92008D7B8A /* KSDenseOptimizer.h */,
+				F803D4731CF351DC003579DA /* KSSparseOptimizer.cpp */,
+				F803D4741CF351DC003579DA /* KSSparseOptimizer.h */,
 				14A109E61CBF335A008591D2 /* KSNormalEquationSolver.h */,
 				14A109E71CBF3508008591D2 /* KSCholeskyDecomposition.h */,
 				14A109E81CBF3BB0008591D2 /* KSNESolverFactory.h */,
@@ -290,6 +295,7 @@
 				E4B69E200A3A1BDC003C02F2 /* main.cpp in Sources */,
 				F8496C631CB1147A00F301C3 /* ofxTimeMeasurements.cpp in Sources */,
 				E4B69E210A3A1BDC003C02F2 /* ofApp.cpp in Sources */,
+				F803D4751CF351DC003579DA /* KSSparseOptimizer.cpp in Sources */,
 				14E2ED6B1CB3D473008D7B8A /* ofTest.cpp in Sources */,
 				14E2ED591CB3AAED008D7B8A /* KSDenseOptimizer.cpp in Sources */,
 			);

--- a/src/System/Math/KSCholeskyDecomposition.h
+++ b/src/System/Math/KSCholeskyDecomposition.h
@@ -12,6 +12,7 @@
 #define KSCholeskyDecomposition_h
 
 #include "KSNormalEquationSolver.h"
+#include "../../../extAddons/Eigen/SparseCholesky"
 
 namespace Kosakasakas {
     
@@ -63,6 +64,34 @@ namespace Kosakasakas {
             dst             = dst + s;
             return true;
         };
+        
+        /**
+         @brief 計算実行
+         
+         実際に計算を行う関数です.
+         コレスキー分解により正規方程式を解きます.
+         @param dst     出力パラメータ行列
+         @param y       残差関数
+         @param j       残差関数のヤコビアン
+         @return 計算の成否
+         */
+        inline bool Solve(KSMatrixSparsed& dst, KSMatrixSparsed& y, KSMatrixSparsed& j)
+        {
+            KSMatrixSparsed jt  = j.transpose();
+            KSMatrixSparsed A   = jt * j;
+            KSMatrixSparsed b   = jt * y * -1.0;
+            Eigen::SimplicialLLT<KSMatrixSparsed> solver;
+            solver.compute(A);
+            if(solver.info()!=Eigen::Success)
+            {
+                return false;
+            }
+            
+            KSMatrixSparsed s   = solver.solve(b);
+            dst                 = dst + s;
+            return true;
+        };
+
     };
     
 } //namespace Kosakasakas {

--- a/src/System/Math/KSConjugateGradient.h
+++ b/src/System/Math/KSConjugateGradient.h
@@ -1,20 +1,22 @@
 //
-//  KSCholeskyDecomposition.h
+//  KSConjugateGradient.h
 //
-//  正規方程式のコレスキー分解によるソルバ
+//  正規方程式の共役勾配法によるソルバ
 //
 //  Copyright (c) 2016年 Takahiro Kosaka. All rights reserved.
-//  Created by Takahiro Kosaka on 2016/04/14.
+//  Created by Takahiro Kosaka on 2016/05/24.
 //
 //  This Source Code Form is subject to the terms of the Mozilla
 //  Public License v. 2.0. If a copy of the MPL was not distributed
 //  with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#ifndef KSCholeskyDecomposition_h
-#define KSCholeskyDecomposition_h
+#ifndef KSConjugateGradient_h
+#define KSConjugateGradient_h
 
 #include "KSNormalEquationSolver.h"
 #include "../../../extAddons/Eigen/SparseCholesky"
+#include "../../../extAddons/Eigen/IterativeLinearSolvers"
+
 
 namespace Kosakasakas {
     
@@ -22,15 +24,15 @@ namespace Kosakasakas {
      @brief 正規方程式のコレスキー分解によるソルバ
      正規方程式をコレスキー分解により解くクラスです.
      */
-    class KSCholeskyDecomposition : public KSNormalEquationSolver
+    class KSConjugateGradient : public KSNormalEquationSolver
     {
     public:
         //! コンストラクタ
-        KSCholeskyDecomposition()
+        KSConjugateGradient()
         {};
         
         //! デストラクタ
-        virtual ~KSCholeskyDecomposition()
+        virtual ~KSConjugateGradient()
         {};
         
         //! 初期化
@@ -51,21 +53,12 @@ namespace Kosakasakas {
          @param dst     出力パラメータ行列
          @param y       残差関数
          @param j       残差関数のヤコビアン
-         @param maxIterations   演算の試行回数(本手法ではこのパラメータは意味は無い)
          @return 計算の成否
          */
         inline bool Solve(KSMatrixXd& dst, KSMatrixXd& y, KSMatrixXd& j, int maxIterations)
         {
-            KSMatrixXd jt   = j.transpose();
-            auto llt        = (jt * j).ldlt();
-            if (llt.info()  != Eigen::Success)
-            {
-                return false;
-            }
-            
-            KSMatrixXd s    = llt.solve(jt * y * -1.0);
-            dst             = dst + s;
-            return true;
+            // Denseを使う予定ないので一旦保留
+            return false;
         };
         
         /**
@@ -76,7 +69,6 @@ namespace Kosakasakas {
          @param dst     出力パラメータ行列
          @param y       残差関数
          @param j       残差関数のヤコビアン
-         @param maxIterations   演算の試行回数(本手法ではこのパラメータは意味は無い)
          @return 計算の成否
          */
         inline bool Solve(KSMatrixSparsed& dst, KSMatrixSparsed& y, KSMatrixSparsed& j, int maxIterations)
@@ -84,21 +76,22 @@ namespace Kosakasakas {
             KSMatrixSparsed jt  = j.transpose();
             KSMatrixSparsed A   = jt * j;
             KSMatrixSparsed b   = jt * y * -1.0;
-            Eigen::SimplicialLLT<KSMatrixSparsed> solver;
+            Eigen::ConjugateGradient<KSMatrixSparsed> solver;
             solver.compute(A);
             if(solver.info()!=Eigen::Success)
             {
                 return false;
             }
-            
+            solver.setMaxIterations(maxIterations);
             KSMatrixSparsed s   = solver.solve(b);
             dst                 = dst + s;
             return true;
         };
-
+        
     };
     
 } //namespace Kosakasakas {
 
 
-#endif /* KSCholeskyDecomposition_h */
+
+#endif /* KSConjugateGradient_h */

--- a/src/System/Math/KSDenseOptimizer.cpp
+++ b/src/System/Math/KSDenseOptimizer.cpp
@@ -17,6 +17,8 @@ using namespace Kosakasakas;
 // コンストラクタ
 KSDenseOptimizer::KSDenseOptimizer()
 : m_IsInitialized(false)
+, m_pNESolver(nullptr)
+, m_MaxIterations(4)
 {}
 
 // デストラクタ
@@ -39,7 +41,11 @@ bool    KSDenseOptimizer::Initialize(KSFunction& residual,
     {
         return false;
     }
-    m_pNESolver     = m_NESolverFactory.Create(NESolverType::CHOLESKY);
+    
+    if (!m_pNESolver)
+    {
+        m_pNESolver     = m_NESolverFactory.Create(NESolverType::CHOLESKY);
+    }
 
     return true;
 }
@@ -60,7 +66,7 @@ bool    KSDenseOptimizer::DoGaussNewtonStep()
     
     KSMatrixXd y    = m_FuncResidual(m_MatParam);
     
-    return m_pNESolver->Solve(m_MatParam, y, j);
+    return m_pNESolver->Solve(m_MatParam, y, j, m_MaxIterations);
 }
 
 // IRLS最適化ステップの実行（ガウス-ニュートン法）
@@ -86,7 +92,7 @@ bool    KSDenseOptimizer::DoGaussNewtonStepIRLS()
     }
     y = w * y;
     
-    return m_pNESolver->Solve(m_MatParam, y, j);
+    return m_pNESolver->Solve(m_MatParam, y, j, m_MaxIterations);
 }
 
 // 残差平方和の取得

--- a/src/System/Math/KSDenseOptimizer.cpp
+++ b/src/System/Math/KSDenseOptimizer.cpp
@@ -1,5 +1,5 @@
 //
-//  KSOptimizerForNLLS.h
+//  KSDenseOptimizer.h
 //
 //  非線形最小二乗問題のための最適化計算クラス
 //
@@ -8,21 +8,21 @@
 //
 //
 
-#include "KSOptimizerForNLLS.h"
+#include "KSDenseOptimizer.h"
 
 using namespace Kosakasakas;
 
 // コンストラクタ
-KSOptimizerForNLLS::KSOptimizerForNLLS()
+KSDenseOptimizer::KSDenseOptimizer()
 : m_IsInitialized(false)
 {}
 
 // デストラクタ
-KSOptimizerForNLLS::~KSOptimizerForNLLS()
+KSDenseOptimizer::~KSDenseOptimizer()
 {}
 
 // 初期化
-bool    KSOptimizerForNLLS::Initialize(KSFunction& residual,
+bool    KSDenseOptimizer::Initialize(KSFunction& residual,
                                        KSFunction& jaconian,
                                        KSMatrixXd& initParam,
                                        KSMatrixXd& data)
@@ -43,7 +43,7 @@ bool    KSOptimizerForNLLS::Initialize(KSFunction& residual,
 }
 
 // 最適化ステップの実行（ガウス-ニュートン法）
-bool    KSOptimizerForNLLS::DoGaussNewtonStep()
+bool    KSDenseOptimizer::DoGaussNewtonStep()
 {
     if (!m_IsInitialized || !m_pNESolver)
     {
@@ -62,7 +62,7 @@ bool    KSOptimizerForNLLS::DoGaussNewtonStep()
 }
 
 // IRLS最適化ステップの実行（ガウス-ニュートン法）
-bool    KSOptimizerForNLLS::DoGaussNewtonStepIRLS()
+bool    KSDenseOptimizer::DoGaussNewtonStepIRLS()
 {
     if (!m_IsInitialized)
     {
@@ -88,13 +88,13 @@ bool    KSOptimizerForNLLS::DoGaussNewtonStepIRLS()
 }
 
 // 残差平方和の取得
-double KSOptimizerForNLLS::GetSquaredResidualsSum()
+double KSDenseOptimizer::GetSquaredResidualsSum()
 {
     return fabs((m_FuncResidual(m_MatParam).transpose() * m_FuncResidual(m_MatParam))(0));
 }
 
 // 正規方程式ソルバの変更
-void    KSOptimizerForNLLS::SwitchNormalEquationSolver(NESolverType type)
+void    KSDenseOptimizer::SwitchNormalEquationSolver(NESolverType type)
 {
     m_pNESolver = m_NESolverFactory.Create(type);
 }

--- a/src/System/Math/KSDenseOptimizer.h
+++ b/src/System/Math/KSDenseOptimizer.h
@@ -1,5 +1,5 @@
 //
-//  KSOptimizerForNLLS.h
+//  KSDenseOptimizer.h
 //
 //  非線形最小二乗問題のための最適化計算クラス
 //
@@ -8,8 +8,8 @@
 //
 //
 
-#ifndef KSOptimizerForNLLS_h
-#define KSOptimizerForNLLS_h
+#ifndef KSDenseOptimizer_h
+#define KSDenseOptimizer_h
 
 #include "KSTypeDef.h"
 #include "memory.h"
@@ -24,13 +24,13 @@ namespace Kosakasakas {
             線形問題も扱えます。
             ソルバにはガウス-ニュートン法を用います。
     */
-    class KSOptimizerForNLLS
+    class KSDenseOptimizer
     {
     public:
         //! コンストラクタ
-        KSOptimizerForNLLS();
+        KSDenseOptimizer();
         //! デストラクタ
-        ~KSOptimizerForNLLS();
+        ~KSDenseOptimizer();
         
         /**
          @brief 初期化
@@ -143,4 +143,4 @@ namespace Kosakasakas {
     
 } //namespace Kosakasakas {
 
-#endif /* KSOptimizerForNLLS_h */
+#endif /* KSDenseOptimizer_h */

--- a/src/System/Math/KSDenseOptimizer.h
+++ b/src/System/Math/KSDenseOptimizer.h
@@ -122,6 +122,18 @@ namespace Kosakasakas {
             m_MatParam  = std::move(paramMat);
         }
         
+        /**
+         @brief ソルバ試行回数のセット
+         
+         正規方程式ソルバの試行回数の最大値をセットします.
+         指定した回数以下で解が収束した場合はその時点で終了します.
+         @param iterations  試行回数
+         */
+        inline void SetMaxIterations(int iterations)
+        {
+            m_MaxIterations = iterations;
+        }
+        
     private:
         //! 正規方程式ソルバへのシェアードポインタ
         typedef std::shared_ptr<KSNormalEquationSolver> NESolverPtr;
@@ -141,6 +153,8 @@ namespace Kosakasakas {
         KSNESolverFactory   m_NESolverFactory;
         //! 正規方程式ソルバのポインタ
         NESolverPtr         m_pNESolver;
+        //! 正規方程式を解く試行回数
+        int m_MaxIterations;
     };
     
 } //namespace Kosakasakas {

--- a/src/System/Math/KSMath.h
+++ b/src/System/Math/KSMath.h
@@ -13,5 +13,6 @@
 
 #include "KSTypeDef.h"
 #include "KSDenseOptimizer.h"
+#include "KSSparseOptimizer.h"
 
 #endif /* KSMath_h */

--- a/src/System/Math/KSMath.h
+++ b/src/System/Math/KSMath.h
@@ -12,6 +12,6 @@
 #define KSMath_h
 
 #include "KSTypeDef.h"
-#include "KSOptimizerForNLLS.h"
+#include "KSDenseOptimizer.h"
 
 #endif /* KSMath_h */

--- a/src/System/Math/KSNESolverFactory.h
+++ b/src/System/Math/KSNESolverFactory.h
@@ -16,6 +16,7 @@
 #include "KSTypeDef.h"
 #include "KSNormalEquationSolver.h"
 #include "KSCholeskyDecomposition.h"
+#include "KSConjugateGradient.h"
 #include "memory.h"
 
 namespace Kosakasakas {
@@ -59,6 +60,10 @@ namespace Kosakasakas {
             switch (type) {
                 case NESolverType::CHOLESKY:
                     pSolver = std::make_shared<KSCholeskyDecomposition>();
+                    break;
+                    
+                case NESolverType::PCG:
+                    pSolver = std::make_shared<KSConjugateGradient>();
                     break;
                     
                 default:

--- a/src/System/Math/KSNormalEquationSolver.h
+++ b/src/System/Math/KSNormalEquationSolver.h
@@ -41,6 +41,18 @@ namespace Kosakasakas {
          @return 計算の成否
          */
         virtual bool    Solve(KSMatrixXd& dst, KSMatrixXd& y, KSMatrixXd& j) = 0;
+        
+        /**
+         @brief 計算実行
+         
+         実際に計算を行う関数です.
+         実装は継承先で定義して下さい.
+         @param dst     出力パラメータ行列
+         @param y       残差関数
+         @param j       残差関数のヤコビアン
+         @return 計算の成否
+         */
+        virtual bool    Solve(KSMatrixSparsed& dst, KSMatrixSparsed& y, KSMatrixSparsed& j) = 0;
     };
     
 } //namespace Kosakasakas {

--- a/src/System/Math/KSNormalEquationSolver.h
+++ b/src/System/Math/KSNormalEquationSolver.h
@@ -40,9 +40,10 @@ namespace Kosakasakas {
          @param dst     出力パラメータ行列
          @param y       残差関数
          @param j       残差関数のヤコビアン
+         @param maxIterations   演算の試行回数
          @return 計算の成否
          */
-        virtual bool    Solve(KSMatrixXd& dst, KSMatrixXd& y, KSMatrixXd& j) = 0;
+        virtual bool    Solve(KSMatrixXd& dst, KSMatrixXd& y, KSMatrixXd& j, int maxIterations) = 0;
         
         /**
          @brief 計算実行
@@ -52,9 +53,10 @@ namespace Kosakasakas {
          @param dst     出力パラメータ行列
          @param y       残差関数
          @param j       残差関数のヤコビアン
+         @param maxIterations   演算の試行回数
          @return 計算の成否
          */
-        virtual bool    Solve(KSMatrixSparsed& dst, KSMatrixSparsed& y, KSMatrixSparsed& j) = 0;
+        virtual bool    Solve(KSMatrixSparsed& dst, KSMatrixSparsed& y, KSMatrixSparsed& j, int maxIterations) = 0;
     };
     
 } //namespace Kosakasakas {

--- a/src/System/Math/KSSparseOptimizer.cpp
+++ b/src/System/Math/KSSparseOptimizer.cpp
@@ -17,6 +17,8 @@ using namespace Kosakasakas;
 // コンストラクタ
 KSSparseOptimizer::KSSparseOptimizer()
 : m_IsInitialized(false)
+, m_pNESolver(nullptr)
+, m_MaxIterations(4)
 {}
 
 // デストラクタ
@@ -39,7 +41,11 @@ bool    KSSparseOptimizer::Initialize(KSFunctionSparse& residual,
     {
         return false;
     }
-    m_pNESolver     = m_NESolverFactory.Create(NESolverType::CHOLESKY);
+    
+    if (!m_pNESolver)
+    {
+        m_pNESolver     = m_NESolverFactory.Create(NESolverType::CHOLESKY);
+    }
     
     return true;
 }
@@ -60,7 +66,7 @@ bool    KSSparseOptimizer::DoGaussNewtonStep()
     
     KSMatrixSparsed y    = m_FuncResidual(m_MatParam);
     
-    return m_pNESolver->Solve(m_MatParam, y, j);
+    return m_pNESolver->Solve(m_MatParam, y, j, m_MaxIterations);
 }
 
 // IRLS最適化ステップの実行（ガウス-ニュートン法）
@@ -87,7 +93,7 @@ bool    KSSparseOptimizer::DoGaussNewtonStepIRLS()
     }
     y = w * y;
     
-    return m_pNESolver->Solve(m_MatParam, y, j);
+    return m_pNESolver->Solve(m_MatParam, y, j, m_MaxIterations);
 }
 
 // 残差平方和の取得

--- a/src/System/Math/KSSparseOptimizer.cpp
+++ b/src/System/Math/KSSparseOptimizer.cpp
@@ -1,31 +1,29 @@
 //
-//  KSDenseOptimizer.h
+//  KSSparseOptimizer.cpp
+//  Face2Face
 //
-//  非線形最小二乗問題のための最適化計算クラス
-//
-//  Copyright (c) 2016年 Takahiro Kosaka. All rights reserved.
-//  Created by Takahiro Kosaka on 2016/04/05.
+//  Created by 小坂 昂大 on 2016/05/23.
 //
 //
 
-#include "KSDenseOptimizer.h"
+#include "KSSparseOptimizer.h"
 
 using namespace Kosakasakas;
 
 // コンストラクタ
-KSDenseOptimizer::KSDenseOptimizer()
+KSSparseOptimizer::KSSparseOptimizer()
 : m_IsInitialized(false)
 {}
 
 // デストラクタ
-KSDenseOptimizer::~KSDenseOptimizer()
+KSSparseOptimizer::~KSSparseOptimizer()
 {}
 
 // 初期化
-bool    KSDenseOptimizer::Initialize(KSFunction& residual,
-                                       KSFunction& jaconian,
-                                       KSMatrixXd& initParam,
-                                       KSMatrixXd& data)
+bool    KSSparseOptimizer::Initialize(KSFunctionSparse& residual,
+                                     KSFunctionSparse& jaconian,
+                                     KSMatrixSparsed& initParam,
+                                     KSMatrixSparsed& data)
 {
     m_FuncResidual  = std::move(residual);
     m_FuncJacobian  = std::move(jaconian);
@@ -38,46 +36,47 @@ bool    KSDenseOptimizer::Initialize(KSFunction& residual,
         return false;
     }
     m_pNESolver     = m_NESolverFactory.Create(NESolverType::CHOLESKY);
-
+    
     return true;
 }
 
 // 最適化ステップの実行（ガウス-ニュートン法）
-bool    KSDenseOptimizer::DoGaussNewtonStep()
+bool    KSSparseOptimizer::DoGaussNewtonStep()
 {
     if (!m_IsInitialized || !m_pNESolver)
     {
         return false;
     }
     
-    KSMatrixXd j    = m_FuncJacobian(m_MatParam);
+    KSMatrixSparsed j    = m_FuncJacobian(m_MatParam);
     if (j.rows() < j.cols())
     {
         return false;
     }
     
-    KSMatrixXd y    = m_FuncResidual(m_MatParam);
+    KSMatrixSparsed y    = m_FuncResidual(m_MatParam);
     
     return m_pNESolver->Solve(m_MatParam, y, j);
 }
 
 // IRLS最適化ステップの実行（ガウス-ニュートン法）
-bool    KSDenseOptimizer::DoGaussNewtonStepIRLS()
+bool    KSSparseOptimizer::DoGaussNewtonStepIRLS()
 {
     if (!m_IsInitialized)
     {
         return false;
     }
     
-    KSMatrixXd j    = m_FuncJacobian(m_MatParam);
+    KSMatrixSparsed j    = m_FuncJacobian(m_MatParam);
     if (j.rows() < j.cols())
     {
         return false;
     }
-    KSMatrixXd y    = m_FuncResidual(m_MatParam);
+    KSMatrixSparsed y    = m_FuncResidual(m_MatParam);
     
     // IRLS用のweightを算出して乗算
-    KSMatrixXd w    = y.col(0).cwiseAbs().cwiseMax(0.00001).cwiseInverse().asDiagonal();
+    KSVectorXd v = y.col(0);
+    auto w = v.cwiseAbs().cwiseMax(0.00001).cwiseInverse().asDiagonal();
     for (int i=0,n=j.cols(); i<n; ++i)
     {
         j.col(i) = w * j.col(i);
@@ -88,14 +87,18 @@ bool    KSDenseOptimizer::DoGaussNewtonStepIRLS()
 }
 
 // 残差平方和の取得
-double KSDenseOptimizer::GetSquaredResidualsSum()
+double KSSparseOptimizer::GetSquaredResidualsSum()
 {
-    return fabs((m_FuncResidual(m_MatParam).transpose() * m_FuncResidual(m_MatParam))(0));
+    KSMatrixSparsed m   = m_FuncResidual(m_MatParam);
+    KSMatrixSparsed mt  = m.transpose();
+    KSMatrixSparsed res = mt * m;
+    return fabs(res.coeff(0, 0));
 }
 
 // 正規方程式ソルバの変更
-void    KSDenseOptimizer::SwitchNormalEquationSolver(NESolverType type)
+void    KSSparseOptimizer::SwitchNormalEquationSolver(NESolverType type)
 {
     m_pNESolver = m_NESolverFactory.Create(type);
 }
+
 

--- a/src/System/Math/KSSparseOptimizer.cpp
+++ b/src/System/Math/KSSparseOptimizer.cpp
@@ -1,10 +1,14 @@
 //
 //  KSSparseOptimizer.cpp
-//  Face2Face
 //
-//  Created by 小坂 昂大 on 2016/05/23.
+//  スパース行列による非線形最小二乗問題のための最適化計算クラス
 //
+//  Copyright (c) 2016年 Takahiro Kosaka. All rights reserved.
+//  Created by Takahiro Kosaka on 2016/05/23.
 //
+//  This Source Code Form is subject to the terms of the Mozilla
+//  Public License v. 2.0. If a copy of the MPL was not distributed
+//  with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "KSSparseOptimizer.h"
 

--- a/src/System/Math/KSSparseOptimizer.h
+++ b/src/System/Math/KSSparseOptimizer.h
@@ -122,6 +122,19 @@ namespace Kosakasakas {
             m_MatParam  = std::move(paramMat);
         }
         
+        /**
+         @brief ソルバ試行回数のセット
+         
+         正規方程式ソルバの試行回数の最大値をセットします.
+         指定した回数以下で解が収束した場合はその時点で終了します.
+         @param iterations  試行回数
+         */
+        inline void SetMaxIterations(int iterations)
+        {
+            m_MaxIterations = iterations;
+        }
+        
+
     private:
         //! 正規方程式ソルバへのシェアードポインタ
         typedef std::shared_ptr<KSNormalEquationSolver> NESolverPtr;
@@ -141,6 +154,8 @@ namespace Kosakasakas {
         KSNESolverFactory   m_NESolverFactory;
         //! 正規方程式ソルバのポインタ
         NESolverPtr         m_pNESolver;
+        //! 正規方程式を解く試行回数
+        int m_MaxIterations;
     };
     
 } //namespace Kosakasakas {

--- a/src/System/Math/KSSparseOptimizer.h
+++ b/src/System/Math/KSSparseOptimizer.h
@@ -1,0 +1,145 @@
+//
+//  KSSparseOptimizer.h
+//  Face2Face
+//
+//  Created by 小坂 昂大 on 2016/05/23.
+//
+//
+
+#ifndef __Face2Face__KSSparseOptimizer__
+#define __Face2Face__KSSparseOptimizer__
+
+#include "KSTypeDef.h"
+#include "memory.h"
+#include <functional>
+#include "KSNormalEquationSolver.h"
+#include "KSNESolverFactory.h"
+
+namespace Kosakasakas {
+    
+    /**
+     @brief 非線形最小二乗問題を扱うための最適化計算クラスです。
+     線形問題も扱えます。
+     ソルバにはガウス-ニュートン法を用います。
+     */
+    class KSSparseOptimizer
+    {
+    public:
+        //! コンストラクタ
+        KSSparseOptimizer();
+        //! デストラクタ
+        ~KSSparseOptimizer();
+        
+        /**
+         @brief 初期化
+         
+         最適化計算クラスを初期化します.
+         各パラメータは内部でstd::moveされ、所有権がこのクラスに渡ってしまう点に注意して下さい。
+         @param residual    残差関数
+         @param jacobian    残差関数のヤコビアン（一次微分）
+         @param param       パラメータの初期値マトリックス
+         @param data        サンプルデータマトリック
+         @return 初期化の成否
+         */
+        bool    Initialize(KSFunctionSparse& residual,
+                           KSFunctionSparse& jaconian,
+                           KSMatrixSparsed& initParam,
+                           KSMatrixSparsed& data);
+        
+        /**
+         @brief 最適化ステップの実行（ガウス-ニュートン法）
+         
+         ガウス-ニュートン法による最適化計算を行います。
+         内部では1回しか最適化計算を行わないため、アプリケーション側で複数回計算ステップを実行してください。
+         実行前に必ずInitializeを呼んでください。
+         @return 初期化の成否
+         */
+        bool    DoGaussNewtonStep();
+        
+        /**
+         @brief IRLS最適化ステップの実行（ガウス-ニュートン法）
+         
+         Iteratively reweighted least squaresをガウス-ニュートン法により最適化計算します。
+         重みの計算は、前ステップの解による残差の逆数を絶対値で使っています。
+         内部では1回しか最適化計算を行わないため、アプリケーション側で複数回計算ステップを実行してください。
+         実行前に必ずInitializeを呼んでください。
+         @return 初期化の成否
+         */
+        bool    DoGaussNewtonStepIRLS();
+        
+        /**
+         @brief 残差平方和の取得
+         
+         現在のパラメータでのサンプルデータとの残差平方和を取得します。
+         @return 残差平方和
+         */
+        double  GetSquaredResidualsSum();
+        
+        /**
+         @brief パラメータマトリックスの取得
+         
+         現在のパラメータマトリックスを取得します。
+         @return パラメータマトリックス
+         */
+        inline const KSMatrixSparsed&    GetParamMat() const
+        {
+            return m_MatParam;
+        }
+        
+        /**
+         @brief サンプルデータマトリックスの取得
+         
+         サンプルデータマトリックスを取得します。
+         @return パラメータマトリックス
+         */
+        inline const KSMatrixSparsed&    GetDataMat() const
+        {
+            return m_MatData;
+        }
+        
+        /**
+         @brief 正規方程式ソルバの変更
+         
+         内部で使う正規方程式のソルバを変更します.
+         デフォルトではコレスキー分解が指定されています.
+         @param type        ソルバー列挙型
+         */
+        void    SwitchNormalEquationSolver(NESolverType type);
+        
+        /**
+         @brief パラメータ行列のセット
+         
+         最適化するパラメータ行列の初期値をセットします.
+         各パラメータは内部でstd::moveされ、所有権がこのクラスに渡ってしまう点に注意して下さい.
+         @param paramMat    パラメータ行列
+         */
+        inline void SetParamMat(KSMatrixSparsed& paramMat)
+        {
+            m_MatParam  = std::move(paramMat);
+        }
+        
+    private:
+        //! 正規方程式ソルバへのシェアードポインタ
+        typedef std::shared_ptr<KSNormalEquationSolver> NESolverPtr;
+        
+        //! 内部初期化されているかどうか
+        bool        m_IsInitialized;
+        //! 残差の関数を保持するオブジェクト
+        KSFunctionSparse  m_FuncResidual;
+        //! 残差のヤコビアンを保持するオブジェクト
+        KSFunctionSparse  m_FuncJacobian;
+        //! パラメータマトリックスを保持するオブジェクト
+        KSMatrixSparsed  m_MatParam;
+        //! サンプルデータマトリックスを保持するオブジェクト
+        KSMatrixSparsed  m_MatData;
+        
+        //! 正規方程式ソルバのファクトリオブジェクト
+        KSNESolverFactory   m_NESolverFactory;
+        //! 正規方程式ソルバのポインタ
+        NESolverPtr         m_pNESolver;
+    };
+    
+} //namespace Kosakasakas {
+
+
+#endif /* defined(__Face2Face__KSSparseOptimizer__) */

--- a/src/System/Math/KSSparseOptimizer.h
+++ b/src/System/Math/KSSparseOptimizer.h
@@ -1,10 +1,14 @@
 //
 //  KSSparseOptimizer.h
-//  Face2Face
 //
-//  Created by 小坂 昂大 on 2016/05/23.
+//  スパース行列による非線形最小二乗問題のための最適化計算クラス
 //
+//  Copyright (c) 2016年 Takahiro Kosaka. All rights reserved.
+//  Created by Takahiro Kosaka on 2016/05/23.
 //
+//  This Source Code Form is subject to the terms of the Mozilla
+//  Public License v. 2.0. If a copy of the MPL was not distributed
+//  with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #ifndef __Face2Face__KSSparseOptimizer__
 #define __Face2Face__KSSparseOptimizer__

--- a/src/System/Math/KSTypeDef.h
+++ b/src/System/Math/KSTypeDef.h
@@ -12,6 +12,7 @@
 #define KSTypeDef_h
 
 #include "../../../extAddons/Eigen/Dense"
+#include "../../../extAddons/Eigen/SparseCore"
 
 namespace Kosakasakas {
 
@@ -22,16 +23,34 @@ namespace Kosakasakas {
     typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>   KSMatrixXd;
     
     /**
+     @brief double精度の任意要素スパースマトリックス
+     現状最適化処理専用で、Eigenラップしただけです。
+     */
+    typedef Eigen::SparseMatrix<double>                             KSMatrixSparsed;
+    
+    /**
      @brief double精度の任意要素ベクトル
      現状最適化処理専用で、Eigenラップしただけです。
      */
     typedef Eigen::Matrix<double, Eigen::Dynamic, 1>                KSVectorXd;
     
     /**
+     @brief double精度の任意要素スパースベクトル
+     現状最適化処理専用で、Eigenラップしただけです。
+     */
+    typedef Eigen::SparseVector<double>                             KSVectorSparsed;
+    
+    /**
      @brief マトリックス引数の任意ファンクタ
      現状最適化処理専用です。
      */
-    typedef std::function<KSMatrixXd(const KSMatrixXd &x)>          KSFunction;
+    typedef std::function<KSMatrixXd(const KSMatrixXd &x)>              KSFunction;
+    
+    /**
+     @brief スパースマトリックス引数の任意ファンクタ
+     現状最適化処理専用です。
+     */
+    typedef std::function<KSMatrixSparsed(const KSMatrixSparsed &x)>    KSFunctionSparse;
     
     /**
      @brief 正規方程式のソルバータイプ

--- a/src/ofTest.cpp
+++ b/src/ofTest.cpp
@@ -43,7 +43,7 @@ bool    ofTest::DoTest()
                 1.02, 1.08, 1.16, 1.24, 1.32;
         
         // オプティマイザの宣言
-        KSOptimizerForNLLS  optimizer;
+        KSDenseOptimizer  optimizer;
         
         // 残差関数
         KSFunction  residual    = [&optimizer](const KSMatrixXd &x)->KSMatrixXd
@@ -152,7 +152,7 @@ bool    ofTest::DoTest()
                     0.050, 0.127, 0.094, 0.2122, 0.2729, 0.2665, 0.3317;
         
         // オプティマイザの宣言
-        KSOptimizerForNLLS  optimizer;
+        KSDenseOptimizer  optimizer;
         
         // 残差関数
         KSFunction  residual    = [&optimizer](const KSMatrixXd &x)->KSMatrixXd

--- a/src/ofTest.cpp
+++ b/src/ofTest.cpp
@@ -225,7 +225,8 @@ bool    ofTest::DoTest()
     // 例題No.3
     {
         // ==================================
-        // 例題No.2と同じ問題をSparse行列で解く
+        // 例題No.2と同じ問題をSparse行列を使い、
+        // 前処理付き共役勾配法を使って解く
         // ==================================
     
         // データセットを登録
@@ -247,6 +248,12 @@ bool    ofTest::DoTest()
         
         // オプティマイザの宣言
         KSSparseOptimizer  optimizer;
+        
+        // ソルバを前処理付き共役勾配法(PGC)に変更
+        optimizer.SwitchNormalEquationSolver(NESolverType::PCG);
+        
+        // PGCの試行回数のセット
+        optimizer.SetMaxIterations(4);
         
         // 残差関数
         KSFunctionSparse  residual    = [&optimizer](const KSMatrixSparsed &x)->KSMatrixSparsed


### PR DESCRIPTION
実際に扱うのはスパース行列なのでそれ用の実装を入れる。
今の所コレスキー分解ソルバしか入っていないので、共役勾配法も作る。
