### PR TITLE
MeanShapeの法線計算結果をキャッシュして生成後の形状に付加してみる

### DIFF
--- a/src/Facehack/FacialModel.cpp
+++ b/src/Facehack/FacialModel.cpp
@@ -49,8 +49,16 @@ bool    FacialModel::Initialize(const float* const alphaCoeffs,
         KSVectorXf shapeCoeff = Map<const AlphaCoeffArray>(alphaCoeffs);
         KSVectorXf albedoCoeff = Map<const AlphaCoeffArray>(betaCoeffs);
         
+        // 法線キャッシュを使用する
+        bool useCachedNormal = true;
+        if (!m_pBaselModel->CacheMeanShapeNormal())
+        {
+            ofLog(OF_LOG_ERROR, "ミーンシェイプの法線キャッシュに失敗しました.");
+            return false;
+        }
+        
         // PCAモデルの書き出し
-        if(!m_pBaselModel->DrawSample(shapeCoeff, albedoCoeff))
+        if(!m_pBaselModel->DrawSample(shapeCoeff, albedoCoeff, useCachedNormal))
         {
             ofLog(OF_LOG_ERROR, "バーセルモデルのサンプリングに失敗しました.");
             return false;

--- a/src/System/MorphableModel/ofKsBaselFaceModel.hpp
+++ b/src/System/MorphableModel/ofKsBaselFaceModel.hpp
@@ -17,6 +17,7 @@
 #include "StatisticalModel.h"
 #include "System/Math/KSMath.h"
 
+#include <vector>
 #include <vtkPolyData.h>
 #include <vector>
 
@@ -43,17 +44,23 @@ namespace Kosakasakas
         void    Finalize();
         
         //! MeanShapeをメッシュに書き込む
-        bool    DrawMean();
+        bool    DrawMean(bool cacheNormal = false);
         //! ランダムサンプリングした結果をメッシュに書き込む
-        bool    DrawRandomSample();
+        bool    DrawRandomSample(bool useCachedNormal = false);
         //! 指定のPCAの主成分値でサンプリングした結果をメッシュに書き込む
-        bool    DrawSample(KSVectorXf& shapeCoeff, KSVectorXf& albedoCoeff);
+        bool    DrawSample(KSVectorXf& shapeCoeff, KSVectorXf& albedoCoeff, bool useCachedNormal = false);
+        //! ミーンシェイプの法線をキャッシュしておく
+        bool    CacheMeanShapeNormal();
         
     protected:
         //! モデルの読み込み
         bool    LoadMesh();
         //! データをメッシュに読み込む
-        bool    SetupMesh(ofMesh& dstMesh, vtkPolyData* pSrcVertices, vtkPolyData* pSrcColors);
+        bool    SetupMesh(ofMesh& dstMesh,
+                          vtkPolyData* pSrcVertices,
+                          vtkPolyData* pSrcColors,
+                          bool cacheNormal      = false,  // 法線をキャッシュするかどうか
+                          bool useCachedNormal  = false); // キャッシュされた法線を使うかどうか
         
     protected:
         // All the statismo classes have to be parameterized with the RepresenterType.
@@ -65,11 +72,14 @@ namespace Kosakasakas
         std::string m_DirPath;
         //! HDF5ファイル名
         std::string m_FileName;
-        
+
         //! basel face modelのキャッシュ(shape)
         StatisticalModelType* m_pBaselModelVertices;
         //! basel face modelのキャッシュ(color)
         StatisticalModelType* m_pBaselModelColors;
+        
+        //! 法線キャッシュ
+        std::vector<ofVec3f>    m_aNormalCache;
     };
 }
 

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -119,11 +119,11 @@ void ofApp::update(){
 void ofApp::draw(){
     
     m_pTestModel->Draw();
-    m_pSrcModel->Draw();
+    //m_pSrcModel->Draw();
     
     // フレームバッファを描画
     m_pTestModel->GetTexture().draw(0, 0);
-    m_pSrcModel->GetTexture().draw(300, 0);
+    //m_pSrcModel->GetTexture().draw(300, 0);
     
     ofDrawBitmapString( "press T : start tracking.", 0, 10);
     ofDrawBitmapString( "test model", 0, 30);


### PR DESCRIPTION
最適化計算時、ヤコビアンを解く際に法線をどうやって計算するかという問題があった。
トライアングルから法線を出しているとあまりに式が煩雑になるため、ここはいっそ定数にできないかと考えた。
そこで実験的にMeanShapeの法線を生成された別Shapeの法線にそのまま適用する仕組みを作ってみた。
これなら法線は定数として扱える。
あくまで人間の顔なら法線はだいたい変わんないだろうという予測でこの近似をしてみたが、描画結果もまぁ気付かないレベルになったので、一旦これでやってみる。
